### PR TITLE
update text color before rendering

### DIFF
--- a/src/tree/Element.mjs
+++ b/src/tree/Element.mjs
@@ -1532,6 +1532,10 @@ export default class Element {
             this.colorBl = v;
             this.colorBr = v;
         }
+        if (Utils.isSpark && (this.texture && (this.texture instanceof TextTexture)))
+        {
+          this.texture.textColor = this.color;
+        }
     }
 
     get colorTop() {
@@ -1706,6 +1710,10 @@ export default class Element {
                 // This allows userland to set dimensions of the Element and then later specify the text.
                 this.texture.w = this.w;
                 this.texture.h = this.h;
+            }
+            if (Utils.isSpark && this.color)
+            {
+              this.texture.textColor = this.color;
             }
         }
         return this.texture;


### PR DESCRIPTION
This change is because, text color is always coming as white in screenshot and not the color given by user seen in screen.

Reason is because, color present in Element core is not updated in Spark platform text canvas. Due to this, text canvas is set with default color white (set as default in lightning) ans same is reflected in screenshot.